### PR TITLE
Hotfix/require slack notifier

### DIFF
--- a/lib/slack_filterable_notifier.rb
+++ b/lib/slack_filterable_notifier.rb
@@ -4,3 +4,4 @@ require 'active_support/core_ext/module/attribute_accessors'
 require 'exception_notification'
 require "slack_filterable_notifier/version"
 require "slack_filterable_notifier/core"
+require "slack-notifier"

--- a/lib/slack_filterable_notifier/core.rb
+++ b/lib/slack_filterable_notifier/core.rb
@@ -2,8 +2,6 @@ module ExceptionNotifier
   class SlackFilterableNotifier < SlackNotifier
     include ExceptionNotifier::BacktraceCleaner
 
-    attr_accessor :notifier
-
     # uniquely with slack notifier
     attr_accessor :skipped_exceptions, :simplified_exceptions, :color_for_simplified
     COLOR_FOR_SIMPIFIED_NOTIFICATION = 'good'
@@ -28,7 +26,7 @@ module ExceptionNotifier
 
         if valid?
           send_notice(exception, options, clean_message, attachments: attchs) do |msg, message_opts|
-            @notifier.ping '', message_opts
+            notifier.ping '', message_opts
           end
           return true
         else

--- a/lib/slack_filterable_notifier/version.rb
+++ b/lib/slack_filterable_notifier/version.rb
@@ -1,3 +1,3 @@
 module SlackFilterableNotifier
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION

* to make slack-notifier internally accessible without letting users to install

* version bumped to 0.3